### PR TITLE
Fix path in macro to be consistent with the documentation

### DIFF
--- a/macros/Steam-Deck-Show-Meetings-8-Macros.kmmacros
+++ b/macros/Steam-Deck-Show-Meetings-8-Macros.kmmacros
@@ -6062,7 +6062,7 @@
 						<key>MacroActionType</key>
 						<string>ExecuteShellScript</string>
 						<key>Path</key>
-						<string>/usr/local/scripts/km-icalbuddy.sh</string>
+						<string>/usr/local/bin/km-icalbuddy.sh</string>
 						<key>Source</key>
 						<string>Nothing</string>
 						<key>Text</key>


### PR DESCRIPTION
Otherwise the script won’t be found.

Signed-off-by: Eric Eggert <mail@yatil.net>